### PR TITLE
Added -e -q -m parameters. Added binary file output and separate metadata text file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ things in a neat way, C++11 functionality snuck into the program and
 therefore a modern, C++11 enabled compiler is needed to 
 compile `rtl_power_fftw`.
 
+## Prerequisites
+
+In order to prepare your environment to build from the sources you have to first install a couple of development libraries.
+This step is needed only the first time.
+
+sudo apt-get install libfftw3-dev
+sudo apt-get install libtclap-dev
+
 ## Installation
 
 To compile the program, cd into the directory where you have cloned the code

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ compile `rtl_power_fftw`.
 In order to prepare your environment to build from the sources you have to first install a couple of development libraries.
 This step is needed only the first time.
 
-sudo apt-get install libfftw3-dev
-sudo apt-get install libtclap-dev
+sudo apt-get install libfftw3-dev  
+sudo apt-get install libtclap-dev  
 
 ## Installation
 

--- a/doc/rtl_power_fftw.1
+++ b/doc/rtl_power_fftw.1
@@ -73,6 +73,11 @@ RTL\-SDR device index of the device used for the measurement.
 .RS
 .RE
 .TP
+.B \f[C]\-e\ <session\ duration>\f[], \f[C]\-\-elapsed\ <session\ duration>\f[]
+Allows to specify the recording duration in hours, sec, mins...
+.RS
+.RE
+.TP
 .B \f[C]\-f\ <Hz|Hz:Hz>\f[], \f[C]\-\-freq\ <Hz|Hz:Hz>\f[]
 Center frequency of the receiver or the frequency range to scan.
 A number can be followed by a \f[C]k\f[], \f[C]M\f[] or \f[C]G\f[]
@@ -84,6 +89,18 @@ Frequency range consists of lower and upper bound, separated with colon.
 .TP
 .B \f[C]\-g\ <1/10th\ of\ dB>\f[], \f[C]\-\-gain\ <1/10th\ of\ dB>\f[]
 Receiver gain, expressed in tenths of a decibel (e.g., 100 means 10 dB).
+.RS
+.RE
+.TP
+.B \f[C]\-l\f[], \f[C]\-\-linear\f[]
+Calculate linear power values instead of logarithmic.
+.RS
+.RE
+.TP
+.B \f[C]\-m\ <file\ name\ without\ extension>\f[], \f[C]\-\-matrix\ <file\ name\ without\ extension>\f[]
+Specify a file name (no extension) and use it to store the power values
+in binary format within a .bin file plus a metadata text file with .met
+extension.
 .RS
 .RE
 .TP
@@ -101,6 +118,13 @@ meaningless).
 .B \f[C]\-p\ <ppm>\f[], \f[C]\-\-ppm\ <ppm>\f[]
 Correct for the oscillator error of RTL\-SDR device.
 The correction should be given in ppm.
+.RS
+.RE
+.TP
+.B \f[C]\-q\f[], \f[C]\-\-quiet\f[]
+Limit verbosity.
+Allows the various printouts to happen only the first time and not on
+every scan.
 .RS
 .RE
 .TP
@@ -377,6 +401,73 @@ Although be noted that omiting the option to specify number of bins
 baseline is a discouraged practise.
 You should always specify \f[C]\-\-bins\f[] along with
 \f[C]\-\-baseline\f[].
+.SH Binary output with metadata
+.PP
+To scan for 5 minutes, with reduced verbosity and writing a binary file
+plus text metafile:
+.IP
+.nf
+\f[C]
+rtl_power_fftw\ \-f\ 144100000:146100000\ \-b\ 500\ \-n\ 100\ \-g\ 350\ \-p\ 0\ \-e\ 5m\ \-q\ \-m\ myscanfilename
+\f[]
+.fi
+.PP
+These parameters will produce a myscanfilename.bin binary file and, when
+the 5 minutes will be elapsed you will get also myscanfilename.met text
+file with this kind of content:
+.PP
+500 # frequency bins (columns)
+.PD 0
+.P
+.PD
+2816 # scans (rows)
+.PD 0
+.P
+.PD
+144100000 # startFreq (Hz)
+.PD 0
+.P
+.PD
+146096000 # endFreq (Hz)
+.PD 0
+.P
+.PD
+4000 # stepFreq (Hz)
+.PD 0
+.P
+.PD
+0.025 # effective integration time secs
+.PD 0
+.P
+.PD
+0.0557726 # avgScanDur (sec)
+.PD 0
+.P
+.PD
+160324152435 # firstAcqTimestamp UTC
+.PD 0
+.P
+.PD
+160324152935 # lastAcqTimestamp UTC
+.PP
+You can use these values for further processing and/or plotting the
+binary file content.
+The binary file is a continuous stream of float values (4 bytes each).
+You get all the columns (the FFT bins) in a scan, one scan after the
+other.
+This matrix like layout can be easily plotted with gnuplot (or similar)
+and has the advantage of keeping minimum file size, maximum precision
+and fast rendering.
+The average scan duration is calculated across the whole scan session (5
+minutes in this case).
+The words columns and rows refer to the planned vertical (waterfall)
+rendering of the data.
+.PP
+Binary file size in this case is: 5,632,000 bytes.
+.PD 0
+.P
+.PD
+File size is directly influenced by parameters \-f \-b \-n \-e .
 .SS AUTHORS
 .PP
 Klemen Blokar <klemen.blokar@ad-vega.si>

--- a/doc/rtl_power_fftw.1.md
+++ b/doc/rtl_power_fftw.1.md
@@ -181,15 +181,15 @@ To scan for 5 minutes, with reduced verbosity and writing a binary file plus tex
 
 These parameters will produce a myscanfilename.bin binary file and, when the 5 minutes will be elapsed you will get also   myscanfilename.met  text file with this kind of content:
 
-500 # frequency bins (columns)
-2816 # scans (rows)
-144100000 # startFreq (Hz)
-146096000 # endFreq (Hz)
-4000 # stepFreq (Hz)
-0.025 # effective integration time secs
-0.0557726 # avgScanDur (sec)
-160324152435 # firstAcqTimestamp UTC
-160324152935 # lastAcqTimestamp UTC
+500 # frequency bins (columns)  
+2816 # scans (rows)  
+144100000 # startFreq (Hz)  
+146096000 # endFreq (Hz)  
+4000 # stepFreq (Hz)  
+0.025 # effective integration time secs  
+0.0557726 # avgScanDur (sec)  
+160324152435 # firstAcqTimestamp UTC  
+160324152935 # lastAcqTimestamp UTC  
 
 You can use these values for further processing and/or plotting the binary file content.
 The binary file is a continuous stream of float values (4 bytes each). You get all the columns (the FFT bins) in a scan, one scan after the other.  This matrix like layout can be easily plotted with gnuplot (or similar) and has the advantage of keeping minimum file size, maximum precision and fast rendering.

--- a/doc/rtl_power_fftw.1.md
+++ b/doc/rtl_power_fftw.1.md
@@ -35,8 +35,8 @@ The program can be stopped gracefully by sending the SIGINT signal to it (pressi
 `-d <device index>`,  `--device <device index>`
 :   RTL-SDR device index of the device used for the measurement.
 
-`-e <session duration>`
-:   this allows to specify the recording duration in sec, mins... etc just like it is possible with rtl-power.
+`-e <session duration>`,  `--elapsed <session duration>`
+:   Allows to specify the recording duration in hours, sec, mins...
 
 `-f <Hz|Hz:Hz>`,  `--freq <Hz|Hz:Hz>`
 :   Center frequency of the receiver or the frequency range to scan. A number can be followed by a `k`, `M` or `G` multiplier, meaning that the frequency is expressed in kilohertz, megahertz or gigahertz. Frequency range consists of lower and upper bound, separated with colon.
@@ -44,8 +44,11 @@ The program can be stopped gracefully by sending the SIGINT signal to it (pressi
 `-g <1/10th of dB>`,  `--gain <1/10th of dB>`
 :   Receiver gain, expressed in tenths of a decibel (e.g., 100 means 10 dB).
 
-`-m <file name without extension>`
-:   this will get a file name (no extension) and use it to store the power values in binary format within a .bin file + a metadata text file with .met extension
+`-l`,  `--linear`
+:   Calculate linear power values instead of logarithmic.
+
+`-m <file name without extension>`,  `--matrix <file name without extension>`
+:   Specify a file name (no extension) and use it to store the power values in binary format within a .bin file plus a metadata text file with .met extension.
 
 `-n <repeats>`,  `--repeats <repeats>`
 :   Number of spectra to average (incompatible with `-t`).
@@ -56,8 +59,8 @@ The program can be stopped gracefully by sending the SIGINT signal to it (pressi
 `-p <ppm>`,  `--ppm <ppm>`
 :   Correct for the oscillator error of RTL-SDR device. The correction should be given in ppm.
 
-`-q`
-:   flag to limit verbosity, will allow the various printouts to happen only the first time and not on every scan
+`-q`,  `--quiet`
+:   Limit verbosity. Allows the various printouts to happen only the first time and not on every scan.
 
 `-r <Hz>`,  `--rate <Hz>`
 :   Sample rate of the receiver in Hz.
@@ -66,8 +69,7 @@ The program can be stopped gracefully by sending the SIGINT signal to it (pressi
 :   Size of the read buffers (leave it as it is unless you know what you are doing).
 
 `-T`,  `--strict-time`
-:   End measurement when the time set with `--time` option is up, regardless
-   of the number of gathered samples.
+:   End measurement when the time set with `--time` option is up, regardless of the number of gathered samples.
 
 `-t <seconds>`,  `--time <seconds>`
 :   Integration time (incompatible with -n). This is an _effective integration time_; see **INTEGRATION TIME** below for more info (in short, the measurement might take *longer* than that).
@@ -170,7 +172,7 @@ In this pipeline, `sed` intervenes by replacing the header and separators writte
 To scan frequencies between 100 MHz and 110 MHz and subtract baseline data from each scan, you could do:
 
     rtl_power_fftw -f 100M:110M -B baseline_data.dat > spectrum.dat
-    
+
 This example also illustrates the fact that for all the options where it is possible, the program selects some safe default values and the options can be omitted. Although be noted that omiting the option to specify number of bins (`-b`) and relying on its default value while subtracting baseline is a discouraged practise. You should always specify `--bins` along with `--baseline`.
 
 # Binary output with metadata
@@ -196,7 +198,7 @@ The binary file is a continuous stream of float values (4 bytes each). You get a
 The average scan duration is calculated across the whole scan session (5 minutes in this case).
 The words columns and rows refer to the planned vertical (waterfall) rendering of the data.
 
-Binary file size in this case is: 5,632,000 bytes
+Binary file size in this case is: 5,632,000 bytes.  
 File size is directly influenced by parameters -f -b -n -e .
 
 ## AUTHORS

--- a/doc/rtl_power_fftw.1.md
+++ b/doc/rtl_power_fftw.1.md
@@ -35,11 +35,17 @@ The program can be stopped gracefully by sending the SIGINT signal to it (pressi
 `-d <device index>`,  `--device <device index>`
 :   RTL-SDR device index of the device used for the measurement.
 
+`-e <session duration>`
+:   this allows to specify the recording duration in sec, mins... etc just like it is possible with rtl-power.
+
 `-f <Hz|Hz:Hz>`,  `--freq <Hz|Hz:Hz>`
 :   Center frequency of the receiver or the frequency range to scan. A number can be followed by a `k`, `M` or `G` multiplier, meaning that the frequency is expressed in kilohertz, megahertz or gigahertz. Frequency range consists of lower and upper bound, separated with colon.
 
 `-g <1/10th of dB>`,  `--gain <1/10th of dB>`
 :   Receiver gain, expressed in tenths of a decibel (e.g., 100 means 10 dB).
+
+`-m <file name without extension>`
+:   this will get a file name (no extension) and use it to store the power values in binary format within a .bin file + a metadata text file with .met extension
 
 `-n <repeats>`,  `--repeats <repeats>`
 :   Number of spectra to average (incompatible with `-t`).
@@ -49,6 +55,9 @@ The program can be stopped gracefully by sending the SIGINT signal to it (pressi
 
 `-p <ppm>`,  `--ppm <ppm>`
 :   Correct for the oscillator error of RTL-SDR device. The correction should be given in ppm.
+
+`-q`
+:   flag to limit verbosity, will allow the various printouts to happen only the first time and not on every scan
 
 `-r <Hz>`,  `--rate <Hz>`
 :   Sample rate of the receiver in Hz.
@@ -164,6 +173,31 @@ To scan frequencies between 100 MHz and 110 MHz and subtract baseline data from 
     
 This example also illustrates the fact that for all the options where it is possible, the program selects some safe default values and the options can be omitted. Although be noted that omiting the option to specify number of bins (`-b`) and relying on its default value while subtracting baseline is a discouraged practise. You should always specify `--bins` along with `--baseline`.
 
+# Binary output with metadata
+
+To scan for 5 minutes, with reduced verbosity and writing a binary file plus text metafile:
+
+	rtl_power_fftw -f 144100000:146100000 -b 500 -n 100 -g 350 -p 0 -e 5m -q -m myscanfilename
+
+These parameters will produce a myscanfilename.bin binary file and, when the 5 minutes will be elapsed you will get also   myscanfilename.met  text file with this kind of content:
+
+500 # frequency bins (columns)
+2816 # scans (rows)
+144100000 # startFreq (Hz)
+146096000 # endFreq (Hz)
+4000 # stepFreq (Hz)
+0.025 # effective integration time secs
+0.0557726 # avgScanDur (sec)
+160324152435 # firstAcqTimestamp UTC
+160324152935 # lastAcqTimestamp UTC
+
+You can use these values for further processing and/or plotting the binary file content.
+The binary file is a continuous stream of float values (4 bytes each). You get all the columns (the FFT bins) in a scan, one scan after the other.  This matrix like layout can be easily plotted with gnuplot (or similar) and has the advantage of keeping minimum file size, maximum precision and fast rendering.
+The average scan duration is calculated across the whole scan session (5 minutes in this case).
+The words columns and rows refer to the planned vertical (waterfall) rendering of the data.
+
+Binary file size in this case is: 5,632,000 bytes
+File size is directly influenced by parameters -f -b -n -e .
 
 ## AUTHORS
 

--- a/src/acquisition.cxx
+++ b/src/acquisition.cxx
@@ -27,7 +27,7 @@
 #include "datastore.h"
 #include "device.h"
 #include "interrupts.h"
-
+#include "metadata.h"
 
 template <typename T>
 std::vector<T> read_inputfile(std::istream* stream) {
@@ -230,7 +230,8 @@ void Acquisition::run() {
   bool success = false;
   for (int tune_try = 0; !success && tune_try < max_tune_tries; tune_try++)
   {
-    std::cerr << "Tuning to " << freq << " Hz (try " << tune_try + 1 << ")" << std::endl;
+    if( (params.outcnt == 0 && params.talkless) || (params.talkless==false) ) std::cerr << "Tuning to " << freq << " Hz (try " << tune_try + 1 << ")" << std::endl;
+
     try {
       rtldev.set_frequency(freq);
       tuned_freq = rtldev.frequency();
@@ -247,7 +248,7 @@ void Acquisition::run() {
     throw TuneError(freq);
   }
 
-  std::cerr << "Device tuned to: " << tuned_freq << " Hz" << std::endl;
+  if( (params.outcnt == 0 && params.talkless) || (params.talkless==false) ) std::cerr << "Device tuned to: " << tuned_freq << " Hz" << std::endl;
   std::fill(data.pwr.begin(), data.pwr.end(), 0);
   data.acquisition_finished = false;
   data.repeats_done = 0;
@@ -256,7 +257,12 @@ void Acquisition::run() {
 
   // Record the start-of-acquisition timestamp.
   startAcqTimestamp = currentDateTime();
-  std::cerr << "Acquisition started at " << startAcqTimestamp << std::endl;
+  time(&scanBeg);
+  if(cntTimeStamps==0) {
+    firstAcqTimestamp = currentDateTime();
+    cntTimeStamps++;
+  }
+  if( (params.outcnt == 0 && params.talkless) || (params.talkless==false) ) std::cerr << "Acquisition started at " << startAcqTimestamp << std::endl;
 
   // Calculate the stop time. This will only be effective if --strict-time was given.
   using steady_clock = std::chrono::steady_clock;
@@ -327,7 +333,12 @@ void Acquisition::run() {
 
   // Record the end-of-acquisition timestamp.
   endAcqTimestamp = currentDateTime();
-  std::cerr << "Acquisition done at " << endAcqTimestamp << std::endl;
+  time(&scanEnd);
+  lastAcqTimestamp = currentDateTime();
+  sumScanDur = sumScanDur + difftime(scanEnd, scanBeg);
+  avgScanDur = sumScanDur / metaRows;
+
+  if( (params.outcnt == 0 && params.talkless) || (params.talkless==false) ) std::cerr << "Acquisition done at " << endAcqTimestamp << std::endl;
 
   status_lock.lock();
   data.acquisition_finished = true;
@@ -347,12 +358,19 @@ void Acquisition::print_summary() const {
 }
 
 void Acquisition::write_data() const {
-  // Print the header
-  std::cout << "# rtl-power-fftw output" << std::endl;
-  std::cout << "# Acquisition start: " << startAcqTimestamp << std::endl;
-  std::cout << "# Acquisition end: " << endAcqTimestamp << std::endl;
-  std::cout << "#" << std::endl;
-  std::cout << "# frequency [Hz] power spectral density [dB/Hz]" << std::endl;
+
+  std::ofstream binfile;
+  float pwrdb = 0.0;
+  double freq = 0.0;
+
+  if(!params.matrixMode) {
+    // Print the header
+    std::cout << "# rtl-power-fftw output" << std::endl;
+    std::cout << "# Acquisition start: " << startAcqTimestamp << std::endl;
+    std::cout << "# Acquisition end: " << endAcqTimestamp << std::endl;
+    std::cout << "#" << std::endl;
+    std::cout << "# frequency [Hz] power spectral density [dB/Hz]" << std::endl;
+  }
 
   //Interpolate the central point, to cancel DC bias.
   data.pwr[params.N/2] = (data.pwr[params.N/2 - 1] + data.pwr[params.N/2+1]) / 2;
@@ -363,26 +381,59 @@ void Acquisition::write_data() const {
     ceil(floor(log10(tuned_freq)) - log10(actual_samplerate/params.N) + 1 + extraDigitsFreq);
   const int significantPlacesPwr = 6;
 
-  for (int i = 0; i < params.N; i++) {
-    double freq = tuned_freq + (i - params.N/2.0) * actual_samplerate / params.N;
-    double pwrdb = 10*log10(data.pwr[i] / data.repeats_done / params.N / actual_samplerate)
-                   - (params.baseline ? aux.baseline_values[i] : 0);
-    std::cout << std::setprecision(significantPlacesFreq)
-              << freq
-              << " "
-              << std::setprecision(significantPlacesPwr)
-              << pwrdb
-              << std::endl;
+  if( params.matrixMode ) {
+    // we'll APPEND a new scan "row" of power values
+    binfile.open(params.bin_file, std::ios::out | std::ios::app | std::ios::binary);
   }
-  // Separate consecutive spectra with empty lines.
-  std::cout << std::endl;
-  std::cout.flush();
+
+  for (int i = 0; i < params.N; i++) {
+    freq = tuned_freq + (i - params.N/2.0) * actual_samplerate / params.N;
+    pwrdb = 10*log10(data.pwr[i] / data.repeats_done / params.N / actual_samplerate)
+                   - (params.baseline ? aux.baseline_values[i] : 0);
+    if( params.matrixMode ) {
+      // we WERE writing a double, so 8 bytes, removed the sizeof()
+      // we are NOW writing a float, so 4 bytes
+      // binary file size for 15 mins with N=100 now 43.4 MB instead of 86.8 MB )
+      binfile.write( (char*)&pwrdb, 4 );
+      if(metaRows==0) {
+          metaCols = metaCols + 1;
+      }
+    }
+    else
+    {
+      std::cout << std::setprecision(significantPlacesFreq)
+                << freq
+                << " "
+                << std::setprecision(significantPlacesPwr)
+                << pwrdb
+                << std::endl;
+    }
+  }
+
+  if( params.matrixMode ) {
+    binfile.close();
+    if( freq >= params.finalfreq ) {
+      metaRows = metaRows + 1;
+    }
+  }
+
+  if( !params.matrixMode ) {
+    // Separate consecutive spectra with empty lines.
+    std::cout << std::endl;
+    std::cout.flush();
+  }
 }
 
 // Get current date/time, format is "YYYY-MM-DD HH:mm:ss UTC"
 std::string Acquisition::currentDateTime() {
   time_t now = std::time(0);
   char buf[80];
-  std::strftime(buf, sizeof(buf), "%Y-%m-%d %X UTC", std::gmtime(&now));
+  if( params.matrixMode ) {
+    std::strftime(buf, sizeof(buf), "%y%m%d%H%M%S", std::gmtime(&now));
+  }
+  else
+  {
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %X UTC", std::gmtime(&now));
+  }
   return buf;
 }

--- a/src/acquisition.cxx
+++ b/src/acquisition.cxx
@@ -388,8 +388,14 @@ void Acquisition::write_data() const {
 
   for (int i = 0; i < params.N; i++) {
     freq = tuned_freq + (i - params.N/2.0) * actual_samplerate / params.N;
-    pwrdb = 10*log10(data.pwr[i] / data.repeats_done / params.N / actual_samplerate)
-                   - (params.baseline ? aux.baseline_values[i] : 0);
+    if( params.linear ) {
+      pwrdb = (data.pwr[i] / data.repeats_done / params.N / actual_samplerate)
+                     - (params.baseline ? aux.baseline_values[i] : 0);
+    }
+    else {
+      pwrdb = 10*log10(data.pwr[i] / data.repeats_done / params.N / actual_samplerate)
+                     - (params.baseline ? aux.baseline_values[i] : 0);
+    }
     if( params.matrixMode ) {
       // we WERE writing a double, so 8 bytes, removed the sizeof()
       // we are NOW writing a float, so 4 bytes

--- a/src/acquisition.h
+++ b/src/acquisition.h
@@ -94,11 +94,13 @@ public:
   void print_summary() const;
   // Write the gathered data to stdout.
   void write_data() const;
+  // Write the frequencies header to stdout (matrix format only)
+  void write_header(Plan plan) const;
 
 protected:
   // A helper function that returns the current date and time in the format
   // "YYYY-MM-DD HH:mm:ss UTC".
-  static std::string currentDateTime();
+  std::string currentDateTime();
 
   const Params& params;
   AuxData& aux;

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -1,0 +1,35 @@
+/*
+* rtl_power_fftw, program for calculating power spectrum from rtl-sdr reciever.
+* Copyright (C) 2015 Klemen Blokar <klemen.blokar@ad-vega.si>
+*                    Andrej Lajovic <andrej.lajovic@ad-vega.si>
+*
+*                    Additions by: Mario Cannistra <mariocannistra@gmail.com>
+*                                 (added this file to manage various metadata)
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef METADATA_H
+#define METADATA_H
+
+#include <time.h>
+
+extern int metaCols, metaRows;
+extern int startFreq, endFreq, stepFreq;
+extern time_t scanEnd, scanBeg;
+extern float avgScanDur, sumScanDur;
+extern std::string firstAcqTimestamp, lastAcqTimestamp;
+extern int cntTimeStamps;
+
+#endif // METADATA_H

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -99,7 +99,7 @@ void ensure_positive_arg(std::list<TCLAP::ValueArg<T>*> list) {
 
 Params::Params(int argc, char** argv) {
   try {
-    TCLAP::CmdLine cmd("Obtain power spectrum from RTL device using FFTW library.", ' ', "1.0-beta1");
+    TCLAP::CmdLine cmd("Obtain power spectrum from RTL device using FFTW library.", ' ', "1.0-beta2");
     TCLAP::ValueArg<int> arg_buffers("","buffers","Number of read buffers (don't touch unless running out of memory).",false,buffers,"buffers");
     cmd.add( arg_buffers );
     TCLAP::ValueArg<std::string> arg_window("w","window","Use window function, from file or stdin.",false,"","file|-");
@@ -122,6 +122,8 @@ Params::Params(int argc, char** argv) {
     cmd.add( arg_matrixMode );
     TCLAP::ValueArg<int64_t> arg_repeats("n","repeats","Number of scans for averaging (incompatible with -t).",false,repeats,"repeats");
     cmd.add( arg_repeats );
+    TCLAP::SwitchArg arg_linear("l","linear","Calculate linear power values instead of logarithmic.", linear);
+    cmd.add( arg_linear );
     TCLAP::ValueArg<int> arg_gain("g","gain","Receiver gain.",false, gain, "1/10th of dB");
     cmd.add( arg_gain );
     TCLAP::ValueArg<std::string> arg_freq("f","freq","Center frequency of the receiver or frequency range to scan.",false,"","Hz | Hz:Hz");
@@ -150,6 +152,7 @@ Params::Params(int argc, char** argv) {
       N++;
       std::cerr << "Number of bins should be even, changing to " << N << "." << std::endl;
     }
+    linear = arg_linear.getValue();
     gain = arg_gain.getValue();
     sample_rate = arg_rate.getValue();
     buffers = arg_buffers.getValue();

--- a/src/params.h
+++ b/src/params.h
@@ -34,7 +34,7 @@ public:
   int dev_index = 0;
   int gain = 372;
   int64_t cfreq = 1420405752;
-  int64_t startfreq = 0; 
+  int64_t startfreq = 0;
   int64_t stopfreq = 0;
   int sample_rate = 2000000;
   double integration_time = 0;
@@ -53,6 +53,16 @@ public:
   bool freq_hopping_isSet = false;
   //It is senseless to waste a full buffer of data unless instructed to do so.
   int64_t repeats = buf_length/(2*N);
+  int outcnt = 0;
+  double session_duration = 0;
+  bool session_duration_isSet = false;
+  bool talkless = false;  // default: verbose
+  bool matrixMode = false;  // default: original rtl-power-fftw output format
+  int finalfreq = 0;
+  std::string matrix_file;  // just name without extension
+  std::string bin_file; // name with .bin extension
+  std::string freq_file; // name with .frq extension
+  std::string meta_file; // name with .met extension
 };
 
 #endif // PARAMS_H

--- a/src/params.h
+++ b/src/params.h
@@ -56,6 +56,7 @@ public:
   int outcnt = 0;
   double session_duration = 0;
   bool session_duration_isSet = false;
+  bool linear = false;
   bool talkless = false;  // default: verbose
   bool matrixMode = false;  // default: original rtl-power-fftw output format
   int finalfreq = 0;

--- a/src/rtl_power_fftw.cxx
+++ b/src/rtl_power_fftw.cxx
@@ -3,6 +3,12 @@
 * Copyright (C) 2015 Klemen Blokar <klemen.blokar@ad-vega.si>
 *                    Andrej Lajovic <andrej.lajovic@ad-vega.si>
 *
+*                    Additions by: Mario Cannistra <mariocannistra@gmail.com>
+*                                 (added -e param for session duration)
+*                                 (added -q flag to limit verbosity)
+*                                 (added -m param to produce binary matrix output
+*                                                 with separate metadata file)
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
@@ -17,6 +23,7 @@
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 #include <iostream>
+#include <fstream>
 #include <rtl-sdr.h>
 
 #include "acquisition.h"
@@ -25,10 +32,27 @@
 #include "exceptions.h"
 #include "interrupts.h"
 #include "params.h"
+#include "metadata.h"
 
+#include <time.h>
+
+std::ofstream binfile, metafile;
+int metaRows = 0;
+int metaCols = 0;
+float avgScanDur = 0.0;
+float sumScanDur = 0.0;
+time_t scanEnd, scanBeg;
+int tunfreq;
+int startFreq, endFreq, stepFreq;
+std::string firstAcqTimestamp, lastAcqTimestamp;
+int cntTimeStamps;
 
 int main(int argc, char **argv)
 {
+  bool do_exit = false;
+  time_t exit_time = 0;
+  bool freqsMetaNeeded = true;
+
   ReturnValue final_retval = ReturnValue::Success;
 
   try {
@@ -39,6 +63,16 @@ int main(int argc, char **argv)
 
     // Set up RTL-SDR device.
     Rtlsdr rtldev(params.dev_index);
+
+    // endless will take precedence on session duration time
+    // so i'll force session_duration_isSet = false if endless has been specified
+    if(params.endless) params.session_duration_isSet = false;
+    if(params.session_duration_isSet)
+    {
+      // get desired session duration from cmd line args:
+      exit_time = (int) params.session_duration;
+      std::cerr << "Scan session duration: " << exit_time << " seconds" << std::endl;
+    }
 
     // Print the available gains and select the one nearest to the requested gain.
     rtldev.print_gains();
@@ -80,6 +114,20 @@ int main(int argc, char **argv)
     // Install a signal handler for detecting Ctrl+C.
     set_CtrlC_handler(true);
 
+    if(params.session_duration_isSet) {
+      // calculate at which time we have to stop looping
+      exit_time = time(NULL) + exit_time;
+    }
+
+    if(params.matrixMode) {
+      //std::ofstream binfile, freqfile, metafile;
+      // let's start truncating the binary file if already exists
+      // we will then write appending (see write_data)
+      binfile.open(params.bin_file, std::ios::out | std::ios::trunc | std::ios::binary);
+      binfile.close();
+    }
+
+    params.finalfreq = plan.freqs_to_tune.back();
     //Read from device and do FFT
     do {
       for (auto iter = plan.freqs_to_tune.begin(); iter != plan.freqs_to_tune.end();) {
@@ -99,24 +147,71 @@ int main(int argc, char **argv)
         }
 
         // Print a summary (number of samples, readouts etc.) to stderr.
-        acquisition.print_summary();
+        if( (params.outcnt == 0 && params.talkless) || (params.talkless==false) ) acquisition.print_summary();
+
+
+        // in matrix mode we'll write a separate file with metadata about the scan session
+        // only once per run
+        if(params.matrixMode && freqsMetaNeeded) {
+          tunfreq = *plan.freqs_to_tune.begin();
+          startFreq = tunfreq + (0 - params.N/2.0) * actual_samplerate / params.N;
+          tunfreq = plan.freqs_to_tune.back();
+          endFreq   = tunfreq + ((params.N - 1) - params.N/2.0) * actual_samplerate / params.N;
+          stepFreq = actual_samplerate / params.N;
+
+          freqsMetaNeeded = false;
+        }
+
         // Write the gathered data to stdout.
         acquisition.write_data();
+
         // Print the histogram of the queue length to stderr.
-        data.printQueueHistogram();
+        if( (params.outcnt == 0 && params.talkless) || (params.talkless==false) ) data.printQueueHistogram();
 
         // Check for interrupts.
         if (checkInterrupt(InterruptState::FinishNow))
           break;
       }
-      // Mark the end of a measurement set with an additional empty line
-      // (one was already output as a terminator for the last data set).
-      std::cout << std::endl;
 
-      // Loop if continuous mode is set, but quit if the frequency list becomes
-      // empty or if the user interrupts the operation.
-    } while (params.endless && plan.freqs_to_tune.size()
-             && !checkInterrupt(InterruptState::FinishPass));
+      // if requested, avoid repeating all the printouts, just do that one time:
+      if( (params.outcnt == 0 && params.talkless) ) params.outcnt++;
+
+      if(params.session_duration_isSet) {
+        // here we manage session duration in seconds:
+        if (time(NULL) >= exit_time) {
+    			do_exit = true;
+          //metaRows = metaRows - 1; // let's fix the row count since we increment after lastfreq bin output
+          std::cerr << "Session duration elapsed." << std::endl;
+          // Mark the end of a measurement set with an additional empty line
+          // (one was already output as a terminator for the last data set).
+          std::cout << std::endl;
+        }
+      }
+
+      if(params.endless) do_exit = false;   // exactly ! will force to never exit
+
+      if( !params.session_duration_isSet && !params.endless ) {
+        do_exit = true; // not an endless, no session duration, so we finish after first run
+      }
+
+      // unless you hit ctrl-c :
+      if(checkInterrupt(InterruptState::FinishPass)) do_exit = true;
+
+    } while ( !do_exit );
+
+    if(params.matrixMode) {
+      metafile.open(params.meta_file, std::ios::out | std::ios::trunc );
+      metafile << metaCols << " # frequency bins (columns)" << std::endl;
+      metafile << metaRows << " # scans (rows)" << std::endl;
+      metafile << startFreq << " # startFreq (Hz)" << std::endl;
+      metafile << endFreq << " # endFreq (Hz)" << std::endl;
+      metafile << stepFreq << " # stepFreq (Hz)" << std::endl;
+      metafile << (double)params.N * data.repeats_done / actual_samplerate << " # effective integration time secs" << std::endl;
+      metafile << avgScanDur << " # avgScanDur (sec)" << std::endl;
+      metafile << firstAcqTimestamp << " # firstAcqTimestamp UTC" << std::endl;
+      metafile << lastAcqTimestamp << " # lastAcqTimestamp UTC" << std::endl;
+      metafile.close();
+    }
 
     if (plan.freqs_to_tune.size() == 0) {
       // No valid frequencies left in the list. This is certainly not OK.

--- a/src/rtl_power_fftw.cxx
+++ b/src/rtl_power_fftw.cxx
@@ -187,6 +187,12 @@ int main(int argc, char **argv)
           std::cout << std::endl;
         }
       }
+      else
+      {
+        // Mark the end of a measurement set with an additional empty line
+        // (one was already output as a terminator for the last data set).
+        std::cout << std::endl;
+      }
 
       if(params.endless) do_exit = false;   // exactly ! will force to never exit
 


### PR DESCRIPTION
Hello Klemen, Andrej.
I recently made some change/additions to your wonderful program rtl-power-fftw in order to leverage it on the Raspberry PI where I need to save the power values in a continuous way for scan sessions lasting for example 30 minutes.
Please see my project here: [https://www.hackster.io/mariocannistra/radio-astronomy-with-rtl-sdr-raspberrypi-and-amazon-aws-iot-45b617](https://www.hackster.io/mariocannistra/radio-astronomy-with-rtl-sdr-raspberrypi-and-amazon-aws-iot-45b617)

For the output I wanted to use a binary format instead of the .csv one in order to:
- obtain the smallest possible size since I'm logging all the night long (CSV's blank delimiters and decimal dots were wasting my precious microSD space)
- keep high the precision on decimal digits saving float values
- obtain a complete stream of binary values representing all the bins for each scan, one scan after the other...
- ...that would allow me to plot the waterfall extremely fast with gnuplot
- ...and then add specific annotations in a more convenient way using python

I added the following command line parameters:
-e param for session duration
	this allows to specify the recording duration in sec, mins... etc
-q flag to limit verbosity
	this will allow the various printouts to happen only the first time, to limit my execution log size
-m param to produce binary matrix output and separate metadata file
	this will get a filename (without extension) and use it to store the power values in binary format within a .bin file + a metadata text file with .met extension

I tried following your coding approach as much as possible and merged the new params in your alphabetical order.
	
Please note that a double was used to store the power value, but that was 8 bytes per value in binary format. I changed that to a float that is only 4 bytes per value and cuts the file size in half. The available precision should still be enough for many usages i think. Very important for me since the Raspberry PI writes on a microSD...

I think the overall result is great since I can finally leverage the ability of your software to specify N average values to integrate for less than 1 second when needed. Plus running multi-MHz scans and storing for several minutes.... all together.

My last desire would actually be the ability to specify a crop percentage but did not have so much time until now. Will see...

Example usage python programs are here: [https://github.com/mariocannistra/radio-astronomy-fftw](https://github.com/mariocannistra/radio-astronomy-fftw)

Kind regards,
Mario