### PR TITLE
Add pkg-config to packages list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ compile `rtl_power_fftw`.
 In order to prepare your environment to build from the sources you have to first install a couple of development libraries.
 This step is needed only the first time.
 
-    sudo apt-get install libfftw3-dev libtclap-dev librtlsdr-dev
+    sudo apt-get install libfftw3-dev libtclap-dev librtlsdr-dev pkg-config
 
 ## Installation
 


### PR DESCRIPTION
pkg-config is not part of the usual build-essential or cmake sets in Debian.