### PR TITLE
add wisdom file option

### DIFF
--- a/src/datastore.cxx
+++ b/src/datastore.cxx
@@ -29,8 +29,18 @@ Datastore::Datastore(const Params& params_, std::vector<float>& window_values_) 
 
   inbuf = (complex*)fftwf_alloc_complex(params.N);
   outbuf = (complex*)fftwf_alloc_complex(params.N);
+
+  if (params.wisdom_file != "") 
+  {
+    fftwf_import_wisdom_from_filename(params.wisdom_file.c_str()); 
+  }
+
   plan = fftwf_plan_dft_1d(params.N, (fftwf_complex*)inbuf, (fftwf_complex*)outbuf,
                           FFTW_FORWARD, FFTW_MEASURE);
+  if (params.wisdom_file != "") 
+  {
+    fftwf_export_wisdom_to_filename(params.wisdom_file.c_str()); 
+  }
 }
 
 Datastore::~Datastore() {

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -140,6 +140,9 @@ Params::Params(int argc, char** argv) {
     TCLAP::ValueArg<std::string> arg_baseline("B","baseline","Subtract baseline, read baseline data from file or stdin.",false,"","file|-");
     cmd.add( arg_baseline );
 
+    TCLAP::ValueArg<std::string> arg_wisdom("W","wisdom","Specify a wisdom file for fftw.",false,"","file");
+    cmd.add( arg_wisdom );
+ 
     cmd.parse(argc, argv);
 
     // Ain't this C++11 f**** magic? Watch this:
@@ -162,6 +165,7 @@ Params::Params(int argc, char** argv) {
     talkless = arg_quiet.getValue();
     strict_time = arg_strict_time.getValue();
     min_overlap = arg_min_overlap.getValue();
+    wisdom_file = arg_wisdom.getValue(); 
     //clipped_output_isSet = arg_clipped.getValue();
 
     // Due to USB specifics, buffer length for reading rtl_sdr device

--- a/src/params.h
+++ b/src/params.h
@@ -64,6 +64,7 @@ public:
   std::string bin_file; // name with .bin extension
   std::string freq_file; // name with .frq extension
   std::string meta_file; // name with .met extension
+  std::string wisdom_file; 
 };
 
 #endif // PARAMS_H


### PR DESCRIPTION
This just adds a wisdom file flag (-W or --wisdom) so that fftw wisdom may be cached to a user-specified file if desired. This is because the planning stage can take a long time for large single-shot spectra. 