### PR TITLE
Fix integer overflow on frequencies >2.14 GHz.

### DIFF
--- a/src/acquisition.cxx
+++ b/src/acquisition.cxx
@@ -213,7 +213,7 @@ Acquisition::Acquisition(const Params& params_,
                          Rtlsdr& rtldev_,
                          Datastore& data_,
                          int actual_samplerate_,
-                         int freq_) :
+                         int64_t freq_) :
   params(params_), aux(aux_), rtldev(rtldev_), data(data_),
   actual_samplerate(actual_samplerate_), freq(freq_)
 { }

--- a/src/acquisition.h
+++ b/src/acquisition.h
@@ -50,7 +50,7 @@ public:
   void print() const;
 
   // List of frequencies to tune to.
-  std::list<int> freqs_to_tune;
+  std::list<int64_t> freqs_to_tune;
   // A cached value of the true sample rate.
   int actual_samplerate;
 
@@ -65,15 +65,15 @@ protected:
 // receiver, so TuneError must not be treated as a definite failure.
 class TuneError : public std::exception {
 public:
-  TuneError(int freq_) : freq(freq_) {}
+  TuneError(int64_t freq_) : freq(freq_) {}
   const char* what() const noexcept {
     return "Could not tune to the given frequency.";
   }
   // The frequency that the receiver was unable to tune to.
-  int frequency() { return freq; }
+  int64_t frequency() { return freq; }
 
 protected:
-  int freq;
+  int64_t freq;
 };
 
 
@@ -85,7 +85,7 @@ public:
               Rtlsdr& rtldev,
               Datastore& data,
               int actual_samplerate,
-              int freq);
+              int64_t freq);
 
   // Run the data acquisition.
   void run();
@@ -109,9 +109,9 @@ protected:
   // A cached version of the actual sample rate.
   int actual_samplerate;
   // The frequency to tune to in this acquisition.
-  int freq;
+  int64_t freq;
   // The actual frequency returned by the device.
-  int tuned_freq;
+  int64_t tuned_freq;
   // Timestamp for the start of the acquisition.
   std::string startAcqTimestamp;
   // Timestamp for the end of the acquisition.

--- a/src/params.cxx
+++ b/src/params.cxx
@@ -26,7 +26,7 @@
 #include "params.h"
 #include "exceptions.h"
 
-int parse_frequency(std::string s) {
+int64_t parse_frequency(std::string s) {
   std::istringstream ss(s);
   double f;
   std::string multiplier;
@@ -39,7 +39,7 @@ int parse_frequency(std::string s) {
     f *= 1e9;
   else if (multiplier != "")
     return -1;
-  return (int)f;
+  return (int64_t)f;
 }
 
 double parse_time(std::string s) {


### PR DESCRIPTION
This changes all variables that store the tuner center frequency to use
`int64_t` to avoid overflowing 32 bit signed integers.

It fixes the following error:

```
$ ./rtl_power_fftw -f 2150M
Invalid frequency given to --freq: -2147483648.
Expecting a positive number, allowing the k,M,G multipliers. Exiting.
```